### PR TITLE
Run database seeding as part of CI (#49)

### DIFF
--- a/.github/workflows/catalog-smoke.yml
+++ b/.github/workflows/catalog-smoke.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   catalog-smoke:
+    if: github.event.pull_request == null || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/catalog-smoke.yml
+++ b/.github/workflows/catalog-smoke.yml
@@ -1,0 +1,72 @@
+name: Catalog smoke test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  catalog-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Configure environment
+        run: cp .env.example .env
+
+      - name: Build dev stack
+        run: bin/compose build
+
+      - name: Start dev stack
+        run: bin/compose up -d
+
+      - name: Wait for CKAN
+        run: |
+          set -euo pipefail
+          url="http://localhost:5000/api/action/status_show"
+          max_attempts=60
+          sleep_seconds=10
+          for attempt in $(seq 1 "$max_attempts"); do
+            if curl -fsS "$url" > /dev/null; then
+              echo "CKAN is ready (attempt ${attempt}/${max_attempts})"
+              exit 0
+            fi
+            echo "Waiting for CKAN... (attempt ${attempt}/${max_attempts})"
+            sleep "$sleep_seconds"
+          done
+          echo "ERROR: CKAN did not become healthy at ${url} within $((max_attempts * sleep_seconds)) seconds" >&2
+          exit 1
+
+      - name: Create sysadmin API token
+        run: |
+          set -euo pipefail
+          CKAN_API_TOKEN="$(./bin/ckan user token add ckan_admin ci-seed-token | tail -1 | tr -d '[:space:]')"
+          echo "::add-mask::${CKAN_API_TOKEN}"
+          echo "CKAN_API_TOKEN=${CKAN_API_TOKEN}" >> "$GITHUB_ENV"
+
+      - name: Seed database
+        run: uv run scripts/seed.py "$CKAN_API_TOKEN"
+
+      - name: Verify catalogue access
+        run: |
+          set -euo pipefail
+          echo "Waiting for Solr indexing after seed..."
+          sleep 10
+          if uv run scripts/verify_catalog.py; then
+            exit 0
+          fi
+          echo "First verify attempt failed; retrying once after additional delay..."
+          sleep 15
+          uv run scripts/verify_catalog.py
+
+      - name: Tear down dev stack
+        if: always()
+        run: bin/compose down -v

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ uv run scripts/verify_catalog.py
 
 Wait until CKAN is healthy (`curl http://localhost:5000/api/action/status_show`) before running, especially right after `bin/compose up`.
 
+> **CI**: Pull requests to `main` also run the [Catalog smoke test](.github/workflows/catalog-smoke.yml) workflow. It brings up the dev stack, seeds data with `scripts/seed.py`, and runs `scripts/verify_catalog.py` — the same checks as above.
+
 > **NOTE**: This is a minimal smoke script, not a full test suite. Broader local test infrastructure is tracked in [opencourts-infra#17](https://github.com/opencourtsfyi/opencourts-infra/issues/17) / [#23](https://github.com/opencourtsfyi/opencourts-infra/issues/23). See [ARCHITECTURE.md § Local verification workflow](ARCHITECTURE.md#local-verification-workflow).
 
 ### Teardown

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ uv run scripts/verify_catalog.py
 
 Wait until CKAN is healthy (`curl http://localhost:5000/api/action/status_show`) before running, especially right after `bin/compose up`.
 
-> **CI**: Pull requests to `main` also run the [Catalog smoke test](.github/workflows/catalog-smoke.yml) workflow. It brings up the dev stack, seeds data with `scripts/seed.py`, and runs `scripts/verify_catalog.py` — the same checks as above.
+> **CI**: Non-draft pull requests to `main`, pushes to `main`, and manual [workflow_dispatch](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) runs execute the [Catalog smoke test](.github/workflows/catalog-smoke.yml) workflow. It brings up the dev stack, seeds data with `scripts/seed.py`, and runs `scripts/verify_catalog.py` — the same checks as above. Draft PRs skip the smoke test to save CI time; mark ready for review or run the workflow manually to trigger it.
 
 > **NOTE**: This is a minimal smoke script, not a full test suite. Broader local test infrastructure is tracked in [opencourts-infra#17](https://github.com/opencourtsfyi/opencourts-infra/issues/17) / [#23](https://github.com/opencourtsfyi/opencourts-infra/issues/23). See [ARCHITECTURE.md § Local verification workflow](ARCHITECTURE.md#local-verification-workflow).
 


### PR DESCRIPTION
Adds a **catalog smoke test** GitHub Actions workflow that exercises database seeding and catalogue verification on every PR to `main`.

- New `.github/workflows/catalog-smoke.yml` — sibling workflow (leaves `build.yml` unchanged)
- Brings up the **dev** stack via `bin/compose`, seeds with `scripts/seed.py`, and runs `scripts/verify_catalog.py` (anonymous Action API + DCAT checks)
- Includes CKAN readiness polling, Solr indexing delay/retry, and `bin/compose down -v` teardown
- Documents the CI check in `README.md`

Local dev workflow is unchanged; this only adds automated coverage in CI.

> **NOTE**: opened as a draft to validate the new workflow on this PR before marking ready for review.

## Test plan

- [x] Local dry-run: `bin/compose up`, seed, `uv run scripts/verify_catalog.py` — all checks passed
- [x] **Catalog smoke test** workflow passes on this PR (up to ~15–30 min)
- [x] **Build locally** workflow still passes (unchanged)
---
- ~~[ ] After merge: `workflow_dispatch` is available for manual reruns from `main`~~
Deferring this test until PR #54 is merged, at which point the the corrected `check-upstream.yml` workflow will be on `main` and manual dispatch can be verified there.
