### PR TITLE
Warn in CI when ckan-docker upstream has unmerged changes

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -2,7 +2,14 @@ name: Check upstream ckan-docker
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
+  schedule:
+    # Mondays 14:00 UTC — alert volunteers even when no PRs are open
+    - cron: '0 14 * * 1'
   workflow_dispatch:
 
 jobs:
@@ -11,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # needed to access tags
+          # Full history so ckan-docker-* merge tags are available to check_upstream.sh
+          fetch-depth: 0
 
       - name: Check for upstream changes
         run: bash scripts/check_upstream.sh

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Then visit [https://localhost:8443](https://localhost:8443). Use `CKAN_SITE_URL=
 
 This repo uses a subset of [ckan/ckan-docker](https://github.com/ckan/ckan-docker). To pull in upstream changes when upgrading CKAN versions:
 
+Pull requests and pushes to `main` also run the [Check upstream ckan-docker](.github/workflows/check-upstream.yml) workflow (weekly on Mondays, or manually from `main` after merge). It compares `ckan-docker/master` to the latest `ckan-docker-*` merge tag; if upstream has moved, GitHub Actions shows a **warning** and the job still passes. After merging upstream, record the new baseline with the tag step below to clear the warning.
+
 ```sh
 # Set up a remote to track changes:
 git remote add ckan-docker https://github.com/ckan/ckan-docker.git

--- a/scripts/check_upstream.sh
+++ b/scripts/check_upstream.sh
@@ -1,18 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+emit_github_warning() {
+  local title="$1"
+  local message="$2"
+
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    local warning_msg="${message//'%'/'%25'}"
+    warning_msg="${warning_msg//$'\r'/'%0D'}"
+    warning_msg="${warning_msg//$'\n'/'%0A'}"
+    echo "::warning title=${title}::${warning_msg}"
+  fi
+}
+
 if ! git remote | grep -q '^ckan-docker$'; then
   git remote add ckan-docker https://github.com/ckan/ckan-docker.git
 fi
 
-git fetch ckan-docker --no-tags --quiet
+if ! git fetch ckan-docker --no-tags --quiet; then
+  echo "error: failed to fetch ckan-docker remote" >&2
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::error title=Upstream ckan-docker::Failed to fetch https://github.com/ckan/ckan-docker.git"
+  fi
+  exit 1
+fi
 
 LAST_TAG=$(git tag --list 'ckan-docker-*' --sort=-creatordate | head -1)
+
+if [ -z "$LAST_TAG" ]; then
+  NO_TAG_MSG="No ckan-docker-* merge tag found. See README (Tracking ckan-docker upstream) to record the last upstream merge."
+  echo "⚠️  $NO_TAG_MSG"
+  emit_github_warning "Upstream ckan-docker" "$NO_TAG_MSG"
+  exit 0
+fi
+
 LAST_MERGED_SHA=${LAST_TAG#ckan-docker-}
 
-CHANGES=$(git log "$LAST_MERGED_SHA"..ckan-docker/master --oneline)
+if ! git rev-parse --verify "${LAST_MERGED_SHA}^{commit}" >/dev/null 2>&1; then
+  BAD_TAG_MSG="Merge tag ${LAST_TAG} points to unknown commit ${LAST_MERGED_SHA}."
+  echo "⚠️  $BAD_TAG_MSG" >&2
+  emit_github_warning "Upstream ckan-docker" "$BAD_TAG_MSG"
+  exit 0
+fi
+
+CHANGES=$(git log "${LAST_MERGED_SHA}"..ckan-docker/master --oneline)
 
 if [ -n "$CHANGES" ]; then
   echo "⚠️  Upstream ckan-docker has unmerged changes since $LAST_TAG:"
   echo "$CHANGES"
+  emit_github_warning "Upstream ckan-docker" "$(printf 'Unmerged upstream changes since %s:\n%s' "$LAST_TAG" "$CHANGES")"
 fi


### PR DESCRIPTION
## Summary
- Emit GitHub Actions warnings when upstream `ckan-docker` has commits since the latest `ckan-docker-*` merge tag
- Harden the check for missing tags and fetch failures (drift warns; fetch errors fail)
- Rename workflow to `check-upstream.yml`, run on `main` PRs/pushes plus weekly schedule
- Document the behavior in README

Closes opencourtsfyi/opencourts-infra#33
- [x] confirm Dave's intent re: "warn, don't block" behavior
  * Actually, I think I found the [original suggestion](https://codewiththecarolinas.slack.com/archives/C09SM10LVRT/p1772804253847949?thread_ts=1772636871.015819&cid=C09SM10LVRT), which compares branch tips for fork-synced repos
  * This would be a  different strategy than what this PR currently does (compare against `ckan-docker-*` merge tags and selectively merge upstream)
  * I'll reach out to Dave directly to verify, though.

## Test plan
- [x] `check-upstream` job succeeds on this PR with **Upstream ckan-docker** annotation
- [x] `build` and other workflows still pass
- [ ] After merge, `workflow_dispatch` works from `main`