### PR TITLE
Add Windows WSL2 local dev quickstart and troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,49 +2,132 @@
 
 The metadata, pipelines, extensions for the CKAN portion of open courts
 
-For system design and machine-readable catalogue APIs (CKAN Action API, DCAT), see [ARCHITECTURE.md](ARCHITECTURE.md).
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md) — catalogue APIs (CKAN Action API, DCAT), system design, and local verification
+- [Troubleshooting](docs/TROUBLESHOOTING.md) — common local dev problems (ports, WSL2, macOS, volumes)
 
 ## Table of contents
 
-- [Architecture](#architecture)
+- [Documentation](#documentation)
 - [Development](#development)
   - [Prerequisites](#prerequisites)
   - [Setup](#setup)
+  - [Common commands](#common-commands)
   - [Seeding Data](#seeding-data)
+  - [Verifying catalogue access](#verifying-catalogue-access)
   - [Teardown](#teardown)
   - [Remote debugging](#remote-debugging)
-  - [OSX](#osx)
   - [Running with HTTPS](#running-with-https)
 - [Tracking ckan-docker upstream](#tracking-ckan-docker-upstream)
 
-## Architecture
-
-Machine-readable catalogues — datasets, resources, and metadata for automated tools and agents — are documented in [ARCHITECTURE.md](ARCHITECTURE.md). That covers the CKAN Action API, DCAT feeds, anonymous vs authenticated access, and local verification via `scripts/verify_catalog.py`.
-
 ## Development
 
-This project is a copy of the [ckan/ckan-docker](https://github.com/ckan/ckan-docker) repository. For more information on local development, see the [ckan-docker development mode instructions](https://github.com/ckan/ckan-docker?tab=readme-ov-file#development-mode).
+This project is forked from [ckan/ckan-docker](https://github.com/ckan/ckan-docker). The upstream [development mode](https://github.com/ckan/ckan-docker?tab=readme-ov-file#development-mode) guide covers Docker internals, `bin/` helper scripts, extensions, HTTPS, and debugging — use it when you need depth beyond this quickstart.
+
+> *Problems starting the stack?* See [Troubleshooting](docs/TROUBLESHOOTING.md).
 
 ### Prerequisites
 
-- A Unix-like development environment for running Docker and the project's shell scripts (examples: Linux, macOS, or Windows with [WSL](https://learn.microsoft.com/en-us/windows/wsl/))
-- [Docker](https://www.docker.com) is installed
-- [uv](https://github.com/astral-sh/uv) is installed
+You need [Docker](https://www.docker.com) and [uv](https://github.com/astral-sh/uv). All `bin/` scripts require a **Unix-like shell** (bash). Run commands from a terminal on Linux, on macOS, or inside WSL2 on Windows.
+
+#### Linux
+
+- Install [Docker Engine](https://docs.docker.com/engine/install/) (Compose plugin included on current installs).
+- Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
+
+#### macOS
+
+- Install [Docker Desktop for Mac](https://docs.docker.com/desktop/setup/install/mac-install/).
+- Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
+- **Apple Silicon Macs** (M1 and later): CKAN images are `amd64` only — set `export DOCKER_DEFAULT_PLATFORM=linux/amd64` before building. Intel Macs run the images natively and do not need this. See [Troubleshooting → macOS](docs/TROUBLESHOOTING.md#macos).
+
+#### Windows
+
+Windows requires WSL2 and Docker Desktop. Follow the steps below to get your environment set up with the repo using both.
+
+> **NOTE**: If you run into issues, see [Troubleshooting → Windows (WSL2)](docs/TROUBLESHOOTING.md#windows-wsl2).
+
+1. Install WSL2 with Ubuntu:
+
+   ```powershell
+   wsl --install -d Ubuntu
+   ```
+
+   Restart the machine if prompted.
+
+2. Install [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop).
+
+3. In Docker Desktop **Settings**:
+   - **General:** enable *Use the WSL 2 based engine*
+   - **Resources → WSL Integration:** enable integration for Ubuntu
+   - Keep Docker Desktop running before continuing.
+
+4. (Recommended) Install the [Visual Studio Code WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) extension in VS Code (or a VS Code–based editor).
+
+5. In PowerShell, clone the repo and `cd` into it:
+
+   ```powershell
+   git clone https://github.com/opencourtsfyi/opencourts-ckan.git
+   cd opencourts-ckan
+   ```
+
+6. From that same PowerShell window, open the project in WSL (for example, if using VS Code):
+
+   ```powershell
+   wsl code .
+   ```
+
+7. In the editor, open **Terminal → New Terminal** and verify Docker:
+
+   ```bash
+   docker version
+   ```
+
+8. Install [uv](https://docs.astral.sh/uv/getting-started/installation/) and ensure it is on your PATH. From the repo root:
+
+   ```bash
+   uv venv --python ">=3.12"
+   ```
+
+##### Notes
+
+* Run all [common commands](#common-commands) from the WSL terminal only. PowerShell and CMD are not supported for this repo’s `bin/` scripts.
+* See [Troubleshooting → Windows (WSL2)](docs/TROUBLESHOOTING.md#windows-wsl2) for slow Docker builds on `/mnt/c/...` and other WSL2 issues.
 
 ### Setup
 
-This project uses Docker and Docker Compose. To get started:
+**NOTE**: this setup guide assumes you are running the solution in [ckan-docker development mode](https://github.com/ckan/ckan-docker?tab=readme-ov-file#development-mode). (See [updating the environment file for development mode](https://github.com/ckan/ckan-docker?tab=readme-ov-file#updating-the-environment-file-for-development-mode) for more information).
+
+#### Steps
 
 | Step | Description | Command/Action |
 | --- | --- | --- |
 | 1 | Copy the environment template | `cp .env.example .env` |
 | 2 | Build the Docker containers | `bin/compose build` |
 | 3 | Start Docker Compose | `bin/compose up` |
-| 4 | Visit the local CKAN site | Open [http://localhost:5000/](http://localhost:5000/) in a browser |
-| 5 | Log in with the default admin credentials | `ckan_admin` / `test1234` |
-| 6 | (Optional) Explore catalogue APIs | See [ARCHITECTURE.md](ARCHITECTURE.md) — seed test data first ([Seeding Data](#seeding-data)) |
+| 4 | Wait until CKAN is healthy | `curl -s http://localhost:5000/api/action/status_show` returns `"success": true` |
+| 5 | Visit the local CKAN site | Open [http://localhost:5000/](http://localhost:5000/) in a browser |
+| 6 | Log in with the default admin credentials | `ckan_admin` / `test1234` |
+| 7 | (Optional) Explore catalogue APIs | See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — seed test data first ([Seeding Data](#seeding-data)) |
 
-> **NOTE**: to run locally using HTTPS, see [Running with HTTPS](#running-with-https). Keep `CKAN_SITE_URL` in `.env` aligned with your HTTP/HTTPS choice; it affects catalogue and download URLs (see [ARCHITECTURE.md](ARCHITECTURE.md)).
+> **NOTE**: to run locally using HTTPS, see [Running with HTTPS](#running-with-https). Keep `CKAN_SITE_URL` in `.env` aligned with your HTTP/HTTPS choice; it affects catalogue and download URLs (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)).
+
+### Common commands
+| Task | Command |
+| --- | --- |
+| Build containers | `bin/compose build` |
+| Start stack | `bin/compose up` |
+| Stop stack | `bin/compose down` |
+| Stop and remove volumes (reset local data) | `bin/compose down -v` — see [Troubleshooting](docs/TROUBLESHOOTING.md#resetting-volumes-and-stale-local-state) |
+| CKAN CLI | `./bin/ckan …` |
+| Seed test data | `uv run scripts/seed.py "$CKAN_API_TOKEN"` |
+| Catalogue smoke test | `uv run scripts/verify_catalog.py` |
+| Check CKAN is up | `curl -s http://localhost:5000/api/action/status_show` |
+
+#### Notes
+If you change `CKAN_PORT_HOST` in `.env`, update `CKAN_SITE_URL` to match and recreate containers. Port conflicts: [Troubleshooting → Port already in use](docs/TROUBLESHOOTING.md#port-already-in-use).
+The `bin/compose` and `bin/ckan` wrappers are described in [ckan-docker development mode](https://github.com/ckan/ckan-docker?tab=readme-ov-file#development-mode).
 
 ### Seeding Data
 
@@ -57,6 +140,7 @@ export CKAN_API_TOKEN="$(./bin/ckan user token add ckan_admin my-test-token | ta
 # seed your database
 uv run scripts/seed.py "$CKAN_API_TOKEN"
 
+# Desired console output:
 # Seeding CKAN at http://localhost:5000...
 # Action 'organization_create' reported conflict for 'test-org' (already exists).
 # Action 'package_create' reported conflict for 'test-package' (already exists).
@@ -66,7 +150,7 @@ uv run scripts/seed.py "$CKAN_API_TOKEN"
 # Action 'resource_create' succeeded for 'Test Data Measures For Justice: NC filters'
 ```
 
-Once you've executed this script you should see a test organization, and datasets on your local development site. The seeded `test-org` and `test-package` datasets are used in the [catalogue API examples](ARCHITECTURE.md#ckan-action-api) in ARCHITECTURE.md.
+Once you've executed this script you should see a test organization, and datasets on your local development site. The seeded `test-org` and `test-package` datasets are used in the [catalogue API examples](docs/ARCHITECTURE.md#ckan-action-api) in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ### Verifying catalogue access
 
@@ -76,78 +160,47 @@ After seeding, run the catalogue smoke script (anonymous read checks — no API 
 uv run scripts/verify_catalog.py
 ```
 
-Wait until CKAN is healthy (`curl http://localhost:5000/api/action/status_show`) before running, especially right after `bin/compose up`.
+Wait until CKAN is healthy (`curl http://localhost:5000/api/action/status_show`) before running, especially right after `bin/compose up`. If checks fail, see [Troubleshooting → CKAN not ready yet](docs/TROUBLESHOOTING.md#ckan-not-ready-yet).
 
 > **CI**: Non-draft pull requests to `main`, pushes to `main`, and manual [workflow_dispatch](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) runs execute the [Catalog smoke test](.github/workflows/catalog-smoke.yml) workflow. It brings up the dev stack, seeds data with `scripts/seed.py`, and runs `scripts/verify_catalog.py` — the same checks as above. Draft PRs skip the smoke test to save CI time; mark ready for review or run the workflow manually to trigger it.
 
-> **NOTE**: This is a minimal smoke script, not a full test suite. Broader local test infrastructure is tracked in [opencourts-infra#17](https://github.com/opencourtsfyi/opencourts-infra/issues/17) / [#23](https://github.com/opencourtsfyi/opencourts-infra/issues/23). See [ARCHITECTURE.md § Local verification workflow](ARCHITECTURE.md#local-verification-workflow).
+> **NOTE**: This is a minimal smoke script, not a full test suite. Broader local test infrastructure is tracked in [opencourts-infra#17](https://github.com/opencourtsfyi/opencourts-infra/issues/17) / [#23](https://github.com/opencourtsfyi/opencourts-infra/issues/23). See [docs/ARCHITECTURE.md § Local verification workflow](docs/ARCHITECTURE.md#local-verification-workflow).
 
 ### Teardown
 
 To remove all Docker resources you have created (for example: containers, volumes):
 
 ```sh
-./bin/compose down -v
+bin/compose down -v
 ```
+
+When to reset volumes and what gets removed: see [Troubleshooting → Resetting volumes](docs/TROUBLESHOOTING.md#resetting-volumes-and-stale-local-state).
 
 ### Remote debugging
 
-To enable remote debugging with VS Code:
-- Enable debugging support in your `.env` file
-- Run this project in development mode.
-- Set up VS Code to attach to a running Docker container.
-
-Then install the source and run your containers:
+1. Set `USE_DEBUGPY_FOR_DEV=true` in `.env` (see [ckan-docker — Remote debugging](https://github.com/ckan/ckan-docker?tab=readme-ov-file#remote-debugging-with-vs-code)).
+2. Install extensions and start the stack:
 
 ```sh
 bin/install_src
 bin/compose up
 ```
 
-Then setup VS Code to debug your instance: [ckan/ckan-docker](https://github.com/ckan/ckan-docker?tab=readme-ov-file#remote-debugging-with-vs-code).
+3. Attach your editor — follow the [ckan-docker VS Code attach steps](https://github.com/ckan/ckan-docker?tab=readme-ov-file#remote-debugging-with-vs-code).
 
-
-> **NOTE**: the containers also support [debugging with pdb](https://github.com/ckan/ckan-docker?tab=readme-ov-file#6-debugging-with-pdb), if you prefer this.
-
-### OSX
-
-#### Apple Silicon
-
-The base images are only built for the amd64 architecture, so you will need to run Docker in emulation mode. To do this, set the following environment variable in your terminal before running the above commands:
-
-```sh
-export DOCKER_DEFAULT_PLATFORM=linux/amd64
-
-docker ...
-```
-
-> **NOTE**: if you see errors like "failed to solve: ckan/ckan-dev:2.11: failed to resolve source metadata for docker.io/ckan/ckan-dev", it's likely you are running on Apple Silicon and forgot to set the `DOCKER_DEFAULT_PLATFORM` environment variable.
-
-#### Port 5000 conflict
-
-Later versions of OSX support "AirPlay Receiver" which uses port 5000 which conflicts with the default CKAN port. You have two choices:
-
-- Turn off AirPlay Receiver in System Preferences -> Sharing -> AirDrop & Handoff -> AirPlay Receiver
-- Change the CKAN port by setting the `CKAN_PORT_HOST` environment variable in your `.env` file to something other than 5000 (e.g. 5001)
+> **NOTE:** the containers also support [debugging with pdb](https://github.com/ckan/ckan-docker?tab=readme-ov-file#6-debugging-with-pdb).
 
 ### Running with HTTPS
 
-The default dev setup serves CKAN over HTTP on port 5000. To test over HTTPS locally, update these settings in `.env`:
-
-```sh
-USE_HTTPS_FOR_DEV=true
-CKAN_SITE_URL=https://localhost:5000
-```
-
-Recreate the containers so the changes take effect:
+For dev HTTPS (`USE_HTTPS_FOR_DEV`, self-signed cert on port 5000), follow [ckan-docker — Running HTTPS on development mode](https://github.com/ckan/ckan-docker?tab=readme-ov-file#running-https-on-development-mode), then recreate containers:
 
 ```sh
 bin/compose down && bin/compose up
 ```
 
-Then visit [https://localhost:5000](https://localhost:5000). Your browser will warn about the self-signed certificate — that is expected for local development. Set `CKAN_SITE_URL=https://localhost:5000` so [DCAT and resource URLs](ARCHITECTURE.md#dcat-feeds) use the correct scheme.
+Keep `CKAN_SITE_URL` aligned with how you reach CKAN — it affects [catalogue and download URLs](docs/ARCHITECTURE.md).
 
-To test the production-style nginx stack instead (HTTPS on port 8443), use `docker-compose.yml` rather than `bin/compose`, and set:
+To test the **production-style nginx stack** (HTTPS on port 8443) instead, use `docker-compose.yml` rather than `bin/compose`. See [ckan-docker § NGINX](https://github.com/ckan/ckan-docker?tab=readme-ov-file#8-nginx) and set in `.env`:
 
 ```sh
 USE_HTTPS_FOR_DEV=false
@@ -159,13 +212,11 @@ CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
 docker compose -f docker-compose.yml up
 ```
 
-Then visit [https://localhost:8443](https://localhost:8443). Use `CKAN_SITE_URL=https://localhost:8443` for correct [catalogue URLs](ARCHITECTURE.md).
+Then visit [https://localhost:8443](https://localhost:8443).
 
 ## Tracking ckan-docker upstream
 
 This repo uses a subset of [ckan/ckan-docker](https://github.com/ckan/ckan-docker). To pull in upstream changes when upgrading CKAN versions:
-
-Pull requests and pushes to `main` also run the [Check upstream ckan-docker](.github/workflows/check-upstream.yml) workflow (weekly on Mondays, or manually from `main` after merge). It compares `ckan-docker/master` to the latest `ckan-docker-*` merge tag; if upstream has moved, GitHub Actions shows a **warning** and the job still passes. After merging upstream, record the new baseline with the tag step below to clear the warning.
 
 ```sh
 # Set up a remote to track changes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes how **opencourts-ckan** exposes machine-readable catalogues for automated tools and AI agents. For local setup and day-to-day development commands, see [README.md](README.md).
+This document describes how **opencourts-ckan** exposes machine-readable catalogues for automated tools and AI agents. For local setup and day-to-day development commands, see [README.md](../README.md). For common setup problems, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ## Table of contents
 
@@ -51,7 +51,7 @@ Client (curl, agent, verify_catalog.py)
 | Environment | Typical base URL | Compose file |
 |-------------|------------------|--------------|
 | Dev (default) | `http://localhost:5000` | `docker-compose.dev.yml` via `bin/compose` |
-| Dev with HTTPS | `https://localhost:5000` | Set `USE_HTTPS_FOR_DEV=true` — see [README § Running with HTTPS](README.md#running-with-https) |
+| Dev with HTTPS | `https://localhost:5000` | Set `USE_HTTPS_FOR_DEV=true` — see [README § Running with HTTPS](../README.md#running-with-https) |
 | Production-style (nginx) | `https://localhost:8443` | `docker-compose.yml` |
 
 All examples below use `http://localhost:5000`. Substitute your base URL when using HTTPS or nginx.
@@ -176,7 +176,7 @@ curl -s "http://localhost:5000/dataset/test-package.jsonld" | head
 
 The default catalog path is `/catalog.{_format}` (configurable via `ckanext.dcat.catalog_endpoint`). See [ckanext-dcat endpoint docs](https://docs.ckan.org/projects/ckanext-dcat/en/latest/endpoints.html).
 
-Catalog endpoints support pagination and filtering (e.g. `?page=2`, `?q=budget`). Public datasets appear after [seeding](README.md#seeding-data).
+Catalog endpoints support pagination and filtering (e.g. `?page=2`, `?q=budget`). Public datasets appear after [seeding](../README.md#seeding-data).
 
 ## Metadata available today
 
@@ -194,7 +194,7 @@ Catalogue responses include CKAN-native fields available without custom extensio
 
 ## Local verification workflow
 
-After [setup and seeding](README.md#seeding-data), run the catalogue smoke script:
+After [setup and seeding](../README.md#seeding-data), run the catalogue smoke script:
 
 ```sh
 uv run scripts/verify_catalog.py

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,186 @@
+# Troubleshooting
+
+Common problems when running the local CKAN dev stack. For setup and day-to-day
+commands, see [README.md](../README.md).
+
+## Table of contents
+
+- [All platforms](#all-platforms)
+  - [Port already in use](#port-already-in-use)
+  - [CKAN not ready yet](#ckan-not-ready-yet)
+  - [Resetting volumes and stale local state](#resetting-volumes-and-stale-local-state)
+- [macOS](#macos)
+  - [Apple Silicon Macs (M1 and later)](#apple-silicon-macs-m1-and-later)
+  - [Port 5000 conflict (AirPlay Receiver)](#port-5000-conflict-airplay-receiver)
+- [Windows (WSL2)](#windows-wsl2)
+- [Linux](#linux)
+- [Related topics](#related-topics)
+- [Still stuck?](#still-stuck)
+
+## All platforms
+
+### Port already in use
+
+**Symptom:** `bin/compose up` fails, CKAN does not respond on [http://localhost:5000](http://localhost:5000), or Docker reports a port bind error.
+
+**Likely cause:** Another process is using the host port mapped to CKAN (default `5000` via `CKAN_PORT_HOST` in `.env`).
+
+**Fix:**
+
+1. Find what is using the port (replace `5000` if you changed `CKAN_PORT_HOST`):
+
+   ```sh
+   # Linux / WSL / macOS
+   ss -tlnp | grep ':5000' || lsof -i :5000
+   ```
+
+2. Stop that process, **or** change the CKAN host port in `.env`:
+
+   ```sh
+   CKAN_PORT_HOST=5001
+   CKAN_SITE_URL=http://localhost:5001
+   ```
+
+3. Recreate containers so the new port and URL take effect:
+
+   ```sh
+   bin/compose down && bin/compose up
+   ```
+
+`CKAN_SITE_URL` must match how you reach CKAN in the browser — it affects catalogue links and seeded resource URLs (see [docs/ARCHITECTURE.md](ARCHITECTURE.md)).
+
+On **macOS**, port 5000 is often taken by AirPlay Receiver — see [Port 5000 conflict (AirPlay Receiver)](#port-5000-conflict-airplay-receiver) below.
+
+### CKAN not ready yet
+
+**Symptom:** `curl http://localhost:5000/api/action/status_show` fails, the CKAN site does not load, or `uv run scripts/verify_catalog.py` errors immediately after `bin/compose up`.
+
+**Likely cause:** Containers are still starting. CKAN, Postgres, and Solr all have health checks; the first boot after a build can take several minutes.
+
+**Fix:**
+
+1. Wait and retry:
+
+   ```sh
+   curl -s http://localhost:5000/api/action/status_show
+   ```
+
+   A healthy CKAN returns JSON with `"success": true`.
+
+2. Check container status:
+
+   ```sh
+   bin/compose ps
+   ```
+
+   Services should show `healthy` (or `running` while health checks are in progress).
+
+3. If a service stays unhealthy, inspect logs:
+
+   ```sh
+   bin/compose logs ckan-dev
+   bin/compose logs db
+   bin/compose logs solr
+   ```
+
+4. After changing `.env`, recreate containers: `bin/compose down && bin/compose up`.
+
+See [README § Verifying catalogue access](../README.md#verifying-catalogue-access) once CKAN is up.
+
+### Resetting volumes and stale local state
+
+**Symptom:** Wrong or old data after schema changes, a bad seed run, Solr search returning nothing, or you want a clean slate.
+
+**Likely cause:** Named Docker volumes from a previous run still hold Postgres, Solr, or CKAN data.
+
+**Fix:** Stop the stack and remove containers **and** volumes:
+
+```sh
+bin/compose down -v
+```
+
+This removes the dev-mode named volumes defined in `docker-compose.dev.yml`:
+
+| Volume | Holds |
+|--------|--------|
+| `pg_data` | PostgreSQL database |
+| `solr_data` | Solr search index |
+| `ckan_storage` | CKAN file storage |
+| `pip_cache`, `site_packages`, `local_bin`, `home_dir` | Dev container caches and installed packages |
+
+**When to use:** corrupted DB, need to re-run migrations from scratch, Solr index out of sync, or after major `.env` / image changes that are easier to fix with a clean volume set.
+
+**After reset:** Run the [README setup steps](../README.md#setup) again (`bin/compose build`, `bin/compose up`, wait for health), then [seed](../README.md#seeding-data) and [verify](../README.md#verifying-catalogue-access) if needed.
+
+`bin/compose down` without `-v` stops containers but **keeps** volumes — use that when you only need to restart, not wipe data.
+
+## macOS
+
+### Apple Silicon Macs (M1 and later)
+
+CKAN’s base images are built for `amd64` (Intel/x86_64). Apple Silicon Macs use `arm64`, so Docker must emulate `amd64`. **Intel Macs** use `amd64` natively and can skip this section. See also [Docker multi-platform builds](https://docs.docker.com/build/building/multi-platform/).
+
+Set this in your terminal **before** `bin/compose build` / `bin/compose up`:
+
+```sh
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+> **NOTE:** If you see errors like `failed to solve: ckan/ckan-dev:2.11: failed to resolve source metadata for docker.io/ckan/ckan-dev`, you are likely on an Apple Silicon Mac and forgot to set `DOCKER_DEFAULT_PLATFORM`.
+
+### Port 5000 conflict (AirPlay Receiver)
+
+Recent macOS versions enable **AirPlay Receiver**, which listens on port 5000 and conflicts with the default CKAN port. Either:
+
+- Turn off AirPlay Receiver: **System Settings → General → AirDrop & Handoff → AirPlay Receiver** (on older macOS: **System Preferences → Sharing → AirDrop & Handoff**)
+- Change the host port: set `CKAN_PORT_HOST` in `.env` to something other than `5000` (e.g. `5001`), update `CKAN_SITE_URL` to match (e.g. `http://localhost:5001`), then `bin/compose down && bin/compose up`
+
+See also [Port already in use](#port-already-in-use) for generic port diagnostics.
+
+## Windows (WSL2)
+
+This repo’s shell scripts (`bin/compose`, `bin/ckan`, etc.) expect a Unix-like environment. Use **WSL2**, not PowerShell or CMD alone.
+
+To open a terminal:
+- Launch the Ubuntu app from the Start menu, or
+- Open Windows Terminal and choose the Ubuntu profile, or
+- In VS Code use Remote WSL / `code .` from a WSL shell.
+
+Docker Desktop setup is covered in [Docker’s WSL guide](https://docs.docker.com/desktop/features/wsl/).
+
+| Symptom | Likely cause | Fix |
+|--------|--------------|-----|
+| Poor editor integration / WSL performance | Editor opened without Visual Studio Code WSL extension | Install/enable the [Visual Studio Code WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) extension, which improves performance when working with files in the WSL environment. |
+| `code` or `cursor`: command not found in WSL | Editor shell command not installed in WSL | Run **Shell Command: Install 'code' command in PATH** from the editor’s Command Palette (once), then retry `wsl code .` or `wsl cursor .` |
+| Slow builds, permission errors, or bind-mount failures | Repo cloned under `/mnt/c/...` | Clone and work under the Linux filesystem, e.g. `~/dev/opencourts-ckan` |
+| `docker: command not found` in WSL | Docker not integrated with your distro | Install [Docker Desktop](https://www.docker.com/products/docker-desktop/), enable the WSL 2 backend, and turn on **Settings → Resources → WSL integration** for your distro |
+| `permission denied` connecting to Docker | Docker Desktop socket access blocked or WSL user not in `docker` group | Ensure Docker Desktop is running and Ubuntu integration is enabled, then run `sudo usermod -aG docker "$USER"` in WSL, `exec bash`, and from PowerShell `wsl --shutdown` before reopening Ubuntu |
+| Editor can’t find files or terminals behave oddly | Project opened via Windows path instead of WSL | In Cursor or VS Code, open the folder **from WSL** (Remote WSL / `cursor .` from a WSL shell in the repo root), not `C:\...` pointing at WSL files |
+| Containers exit unexpectedly or builds fail with memory errors | Default WSL/Docker memory too low for this stack | Raise **Docker Desktop → Settings → Resources** limits and/or set `memory=8GB` (or higher) in [`%USERPROFILE%\.wslconfig`](https://learn.microsoft.com/en-us/windows/wsl/wsl-config#configure-global-options-with-wslconfig), then run `wsl --shutdown` and restart WSL |
+| Port bind errors despite nothing obvious on Windows | Another WSL service or prior container | From WSL: `ss -tlnp | grep ':5000'`; run `bin/compose down` before changing ports |
+
+The `./src` bind mount in dev mode must live on a path Docker can mount efficiently — keep the repo on the WSL filesystem, not under `/mnt/c/`.
+
+For general Docker Compose behaviour (logs, rebuilding, extension mounts), see [ckan-docker development mode](https://github.com/ckan/ckan-docker?tab=readme-ov-file#development-mode).
+
+## Linux
+
+| Symptom | Likely cause | Fix |
+|--------|--------------|-----|
+| `permission denied` connecting to Docker | User not in `docker` group | Add your user to the `docker` group and re-login, or use `sudo` (see [Docker Engine install](https://docs.docker.com/engine/install/)) |
+| Port already in use | Another local service on `5000` | [Port already in use](#port-already-in-use) |
+
+## Related topics
+
+| Topic | Where to look |
+|-------|----------------|
+| HTTPS / self-signed certificate warnings | [README § Running with HTTPS](../README.md#running-with-https) and [ckan-docker — Running HTTPS on development mode](https://github.com/ckan/ckan-docker?tab=readme-ov-file#running-https-on-development-mode) |
+| Remote debugging (VS Code / Cursor) | [README § Remote debugging](../README.md#remote-debugging) |
+| Upstream image or compose changes | [README § Tracking ckan-docker upstream](../README.md#tracking-ckan-docker-upstream) |
+| Catalogue / API smoke checks | [docs/ARCHITECTURE.md § Local verification workflow](ARCHITECTURE.md#local-verification-workflow) |
+
+## Still stuck?
+
+1. Capture output from `bin/compose ps` and `bin/compose logs ckan-dev` (last 50 lines).
+2. Check [ckan-docker development mode](https://github.com/ckan/ckan-docker?tab=readme-ov-file#development-mode) for generic CKAN-on-Docker issues.
+3. Open an issue in [opencourts-ckan](https://github.com/opencourtsfyi/opencourts-ckan/issues) with your OS, Docker version (`docker version`), and the logs above.


### PR DESCRIPTION
## Changes

- Updated `README.md`
  - clarified Windows WSL2 setup
  - moved detailed Docker socket / permission troubleshooting into `docs/TROUBLESHOOTING.md`
  - improved terminal-opening guidance for Ubuntu/WSL and VS Code
  - fixed numbering and formatting in the Windows instructions
- Updated `docs/TROUBLESHOOTING.md`
  - added WSL terminal guidance
  - added Docker permission troubleshooting for WSL/Docker socket issues
  - improved Windows WSL2 diagnostics
- Updated `docs/ARCHITECTURE.md`
  - minor doc-path/format reference adjustment

## Tested

- Windows + WSL prerequisites and setup using a combination of VS Code and Cursor

## Scope

- Documentation-only
- Focused on local development onboarding and troubleshooting
- No code or runtime behavior changes