### PR TITLE
Add cross-platform dev stack verification checklist (FR-18 / #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 The metadata, pipelines, extensions for the CKAN portion of open courts
 
-For system design and machine-readable catalogue APIs (CKAN Action API, DCAT), see [ARCHITECTURE.md](ARCHITECTURE.md).
+For system design and machine-readable catalogue APIs (CKAN Action API, DCAT), see [Architecture](docs/ARCHITECTURE.md).
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md) — catalogue APIs (CKAN Action API, DCAT), system design, and local verification
+- [Cross-platform verification](docs/CROSS_PLATFORM_VERIFICATION.md) — dev stack sign-off checklist (Linux CI + manual macOS/Windows); run the full protocol when compose or smoke scripts change
 
 ## Table of contents
 
+- [Documentation](#documentation)
 - [Architecture](#architecture)
 - [Development](#development)
   - [Prerequisites](#prerequisites)
@@ -19,7 +25,7 @@ For system design and machine-readable catalogue APIs (CKAN Action API, DCAT), s
 
 ## Architecture
 
-Machine-readable catalogues — datasets, resources, and metadata for automated tools and agents — are documented in [ARCHITECTURE.md](ARCHITECTURE.md). That covers the CKAN Action API, DCAT feeds, anonymous vs authenticated access, and local verification via `scripts/verify_catalog.py`.
+Machine-readable catalogues — datasets, resources, and metadata for automated tools and agents — are documented in [Architecture](docs/ARCHITECTURE.md). That covers the CKAN Action API, DCAT feeds, anonymous vs authenticated access, and local verification via `scripts/verify_catalog.py`.
 
 ## Development
 
@@ -42,9 +48,9 @@ This project uses Docker and Docker Compose. To get started:
 | 3 | Start Docker Compose | `bin/compose up` |
 | 4 | Visit the local CKAN site | Open [http://localhost:5000/](http://localhost:5000/) in a browser |
 | 5 | Log in with the default admin credentials | `ckan_admin` / `test1234` |
-| 6 | (Optional) Explore catalogue APIs | See [ARCHITECTURE.md](ARCHITECTURE.md) — seed test data first ([Seeding Data](#seeding-data)) |
+| 6 | (Optional) Explore catalogue APIs | See [Architecture](docs/ARCHITECTURE.md) — seed test data first ([Seeding Data](#seeding-data)) |
 
-> **NOTE**: to run locally using HTTPS, see [Running with HTTPS](#running-with-https). Keep `CKAN_SITE_URL` in `.env` aligned with your HTTP/HTTPS choice; it affects catalogue and download URLs (see [ARCHITECTURE.md](ARCHITECTURE.md)).
+> **NOTE**: to run locally using HTTPS, see [Running with HTTPS](#running-with-https). Keep `CKAN_SITE_URL` in `.env` aligned with your HTTP/HTTPS choice; it affects catalogue and download URLs (see [Architecture](docs/ARCHITECTURE.md)).
 
 ### Seeding Data
 
@@ -66,7 +72,7 @@ uv run scripts/seed.py "$CKAN_API_TOKEN"
 # Action 'resource_create' succeeded for 'Test Data Measures For Justice: NC filters'
 ```
 
-Once you've executed this script you should see a test organization, and datasets on your local development site. The seeded `test-org` and `test-package` datasets are used in the [catalogue API examples](ARCHITECTURE.md#ckan-action-api) in ARCHITECTURE.md.
+Once you've executed this script you should see a test organization, and datasets on your local development site. The seeded `test-org` and `test-package` datasets are used in the [catalogue API examples](docs/ARCHITECTURE.md#ckan-action-api) in Architecture.
 
 ### Verifying catalogue access
 
@@ -78,9 +84,9 @@ uv run scripts/verify_catalog.py
 
 Wait until CKAN is healthy (`curl http://localhost:5000/api/action/status_show`) before running, especially right after `bin/compose up`.
 
-> **CI**: Non-draft pull requests to `main`, pushes to `main`, and manual [workflow_dispatch](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) runs execute the [Catalog smoke test](.github/workflows/catalog-smoke.yml) workflow. It brings up the dev stack, seeds data with `scripts/seed.py`, and runs `scripts/verify_catalog.py` — the same checks as above. Draft PRs skip the smoke test to save CI time; mark ready for review or run the workflow manually to trigger it.
+> **CI**: Non-draft pull requests to `main`, pushes to `main`, and manual [workflow_dispatch](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) runs execute the [Catalog smoke test](.github/workflows/catalog-smoke.yml) workflow. It brings up the dev stack, seeds data with `scripts/seed.py`, and runs `scripts/verify_catalog.py` — the same checks as above. Draft PRs skip the smoke test to save CI time; mark ready for review or run the workflow manually to trigger it. Linux coverage is automated; macOS and Windows (WSL2) manual sign-off is tracked in [Cross-platform verification](docs/CROSS_PLATFORM_VERIFICATION.md).
 
-> **NOTE**: This is a minimal smoke script, not a full test suite. Broader local test infrastructure is tracked in [opencourts-infra#17](https://github.com/opencourtsfyi/opencourts-infra/issues/17) / [#23](https://github.com/opencourtsfyi/opencourts-infra/issues/23). See [ARCHITECTURE.md § Local verification workflow](ARCHITECTURE.md#local-verification-workflow).
+> **NOTE**: This is a minimal smoke script, not a full test suite. Broader local test infrastructure is tracked in [opencourts-infra#17](https://github.com/opencourtsfyi/opencourts-infra/issues/17) / [#23](https://github.com/opencourtsfyi/opencourts-infra/issues/23). See [Architecture § Local verification workflow](docs/ARCHITECTURE.md#local-verification-workflow).
 
 ### Teardown
 
@@ -145,7 +151,7 @@ Recreate the containers so the changes take effect:
 bin/compose down && bin/compose up
 ```
 
-Then visit [https://localhost:5000](https://localhost:5000). Your browser will warn about the self-signed certificate — that is expected for local development. Set `CKAN_SITE_URL=https://localhost:5000` so [DCAT and resource URLs](ARCHITECTURE.md#dcat-feeds) use the correct scheme.
+Then visit [https://localhost:5000](https://localhost:5000). Your browser will warn about the self-signed certificate — that is expected for local development. Set `CKAN_SITE_URL=https://localhost:5000` so [DCAT and resource URLs](docs/ARCHITECTURE.md#dcat-feeds) use the correct scheme.
 
 To test the production-style nginx stack instead (HTTPS on port 8443), use `docker-compose.yml` rather than `bin/compose`, and set:
 
@@ -159,7 +165,7 @@ CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
 docker compose -f docker-compose.yml up
 ```
 
-Then visit [https://localhost:8443](https://localhost:8443). Use `CKAN_SITE_URL=https://localhost:8443` for correct [catalogue URLs](ARCHITECTURE.md).
+Then visit [https://localhost:8443](https://localhost:8443). Use `CKAN_SITE_URL=https://localhost:8443` for correct [catalogue URLs](docs/ARCHITECTURE.md).
 
 ## Tracking ckan-docker upstream
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes how **opencourts-ckan** exposes machine-readable catalogues for automated tools and AI agents. For local setup and day-to-day development commands, see [README.md](README.md).
+This document describes how **opencourts-ckan** exposes machine-readable catalogues for automated tools and AI agents. For local setup and day-to-day development commands, see [README.md](../README.md). For common setup problems, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ## Table of contents
 
@@ -51,7 +51,7 @@ Client (curl, agent, verify_catalog.py)
 | Environment | Typical base URL | Compose file |
 |-------------|------------------|--------------|
 | Dev (default) | `http://localhost:5000` | `docker-compose.dev.yml` via `bin/compose` |
-| Dev with HTTPS | `https://localhost:5000` | Set `USE_HTTPS_FOR_DEV=true` — see [README § Running with HTTPS](README.md#running-with-https) |
+| Dev with HTTPS | `https://localhost:5000` | Set `USE_HTTPS_FOR_DEV=true` — see [README § Running with HTTPS](../README.md#running-with-https) |
 | Production-style (nginx) | `https://localhost:8443` | `docker-compose.yml` |
 
 All examples below use `http://localhost:5000`. Substitute your base URL when using HTTPS or nginx.
@@ -176,7 +176,7 @@ curl -s "http://localhost:5000/dataset/test-package.jsonld" | head
 
 The default catalog path is `/catalog.{_format}` (configurable via `ckanext.dcat.catalog_endpoint`). See [ckanext-dcat endpoint docs](https://docs.ckan.org/projects/ckanext-dcat/en/latest/endpoints.html).
 
-Catalog endpoints support pagination and filtering (e.g. `?page=2`, `?q=budget`). Public datasets appear after [seeding](README.md#seeding-data).
+Catalog endpoints support pagination and filtering (e.g. `?page=2`, `?q=budget`). Public datasets appear after [seeding](../README.md#seeding-data).
 
 ## Metadata available today
 
@@ -194,7 +194,7 @@ Catalogue responses include CKAN-native fields available without custom extensio
 
 ## Local verification workflow
 
-After [setup and seeding](README.md#seeding-data), run the catalogue smoke script:
+After [setup and seeding](../README.md#seeding-data), run the catalogue smoke script:
 
 ```sh
 uv run scripts/verify_catalog.py
@@ -212,6 +212,8 @@ uv run scripts/verify_catalog.py
 | DCAT catalogue | `GET /catalog.jsonld` | Seeded dataset present in RDF feed |
 
 This is intentionally minimal — a single smoke script, not pytest or a shared test runner. Generic portal/DB/storage smoke tests and CI integration are tracked in [opencourts-infra#17](https://github.com/opencourtsfyi/opencourts-infra/issues/17) and [#23](https://github.com/opencourtsfyi/opencourts-infra/issues/23).
+
+For the full end-to-end protocol (compose up → seed → smoke → down) on each supported OS, see [Cross-platform verification](CROSS_PLATFORM_VERIFICATION.md). Linux is validated in CI via [catalog-smoke.yml](../.github/workflows/catalog-smoke.yml); macOS and Windows (WSL2) use manual sign-off rows in that doc.
 
 The script covers both the CKAN Action API and DCAT layers; manual `curl` checks are optional if you need to debug a single endpoint.
 

--- a/docs/CROSS_PLATFORM_VERIFICATION.md
+++ b/docs/CROSS_PLATFORM_VERIFICATION.md
@@ -1,0 +1,100 @@
+# Cross-platform dev stack verification
+
+Maintained checklist for [opencourts-infra#25](https://github.com/opencourtsfyi/opencourts-infra/issues/25): validate that the local dev stack works on **Linux**, **macOS**, and **Windows (WSL2)**.
+
+Setup instructions live in [README.md](../README.md). Platform-specific fixes: [TROUBLESHOOTING.md](TROUBLESHOOTING.md) when present ([opencourts-ckan#55](https://github.com/opencourtsfyi/opencourts-ckan/pull/55)); otherwise README [Prerequisites](../README.md#prerequisites) and [OSX](../README.md#osx).
+
+This document is the **test protocol and sign-off log** — not a second setup guide.
+
+## Table of contents
+
+- [Validation strategy](#validation-strategy)
+- [Verification](#verification)
+  - [Manual](#manual)
+  - [Script](#script)
+- [OS-specific caveats](#os-specific-caveats)
+- [Sign-off log](#sign-off-log)
+- [Future automation](#future-automation)
+
+## Validation strategy
+
+| OS family | How we validate | Why |
+|-----------|-----------------|-----|
+| **Linux** | Automated — [Catalog smoke test](../.github/workflows/catalog-smoke.yml) on `ubuntu-latest` for every non-draft PR to `main` | Same sequence as this checklist; runs on every merge |
+| **macOS** | Manual sign-off using the steps below | Docker Desktop + Apple Silicon behaviour is not reproduced reliably on GitHub-hosted runners |
+| **Windows** | Manual sign-off in **WSL2** using the steps below | Documented contributor path is Ubuntu/WSL + bash `bin/` scripts, not native PowerShell/CMD |
+
+Full cross-OS automation (self-hosted runners, scheduled doc-as-tests, cloud Mac) is **deferred** — see [Future automation](#future-automation).
+
+Re-run the manual checklist when compose files, Dockerfiles, seed scripts, or `verify_catalog.py` change in ways that could affect local startup.
+
+## Verification
+
+### Manual
+
+Run each step manually from the **repository root** in a bash shell OR run the [verification script](#script) below.
+
+> **NOTE**: this sequence matches the [`catalog-smoke.yml`](../.github/workflows/catalog-smoke.yml) workflow in CI.
+
+| Step | Command / action | Pass criteria |
+|------|------------------|---------------|
+| 1. Setup | `cp .env.example .env` | `.env` present |
+| 2. Compose up | `bin/compose build && bin/compose up -d` | All services start; no build errors |
+| 3. Ready | `curl -fsS http://localhost:5000/api/action/status_show` | HTTP 200 (retry until healthy — CKAN first boot can take several minutes) |
+| 4. Seed | Create sysadmin API token, then `uv run scripts/seed.py "$CKAN_API_TOKEN"` | Seed completes without error (409 "already exists" is OK on re-runs) |
+| 5. Smoke test | `uv run scripts/verify_catalog.py` | Exit code 0 |
+| 6. Compose down | `bin/compose down -v` | Containers removed; named volumes cleared |
+
+### Script
+
+#### macOS Apple Silicon users only
+Set the platform before running:
+>
+> ```sh
+> export DOCKER_DEFAULT_PLATFORM=linux/amd64
+> ```
+
+#### All users
+From the repository root, run:
+
+```sh
+./scripts/verify_dev_stack.sh
+```
+
+This script runs all six checklist steps in order, prints `PASS:` / `FAIL:` for each step, and ends with a clear **verification passed** or **verification failed** summary. It exits 0 on success and non-zero on failure (same as CI).
+
+## OS-specific caveats
+
+Read these **before** step 2. Details and fixes are in [TROUBLESHOOTING.md](TROUBLESHOOTING.md) (or README until #55 merges).
+
+| OS | Before you run | Common blockers |
+|----|----------------|-----------------|
+| **Linux** | Docker Engine or Docker CE with Compose plugin; [uv](https://docs.astral.sh/uv/) installed | Port 5000 in use (`ss -tlnp \| grep ':5000'`); user not in `docker` group |
+| **macOS** | Docker Desktop for Mac; `uv` installed | **Apple Silicon:** `export DOCKER_DEFAULT_PLATFORM=linux/amd64` before build; AirPlay Receiver on port 5000 |
+| **Windows (WSL2)** | WSL2 + Ubuntu; Docker Desktop with WSL integration; repo cloned under `/home/...`, **not** `/mnt/c/...` | Running from PowerShell/CMD instead of WSL; Docker socket permissions; opening project via `C:\...` instead of Remote WSL |
+
+| Topic | Where to look |
+|-------|----------------|
+| Port conflicts | [TROUBLESHOOTING → Port already in use](TROUBLESHOOTING.md#port-already-in-use) |
+| macOS / Apple Silicon | [TROUBLESHOOTING → macOS](TROUBLESHOOTING.md#macos) |
+| Windows / WSL2 | [README → Prerequisites](../README.md#prerequisites) (see [TROUBLESHOOTING → Windows (WSL2)](TROUBLESHOOTING.md#windows-wsl2) when available) |
+| CKAN not ready yet | [TROUBLESHOOTING → CKAN not ready yet](TROUBLESHOOTING.md#ckan-not-ready-yet) |
+| Reset stale state | [TROUBLESHOOTING → Resetting volumes](TROUBLESHOOTING.md#resetting-volumes-and-stale-local-state) |
+| What the smoke script checks | [ARCHITECTURE → Local verification workflow](ARCHITECTURE.md#local-verification-workflow) |
+
+## Sign-off log
+
+Update this table when a maintainer completes a manual run or when CI behaviour changes.
+
+| OS | Last verified | Verified by | Environment | Up | Seed | Smoke | Down | Notes |
+|----|---------------|-------------|-------------|:--:|:----:|:-----:|:----:|-------|
+| Linux | *(automated)* | [`catalog-smoke.yml`](../.github/workflows/catalog-smoke.yml) | GitHub `ubuntu-latest` | ✅ | ✅ | ✅ | ✅ | Every non-draft PR to `main` |
+| Windows (WSL2) | 2026-06-25 | @jtasse | WSL2 + Docker Desktop; VS Code and Cursor | ✅ | ✅ | ✅ | ✅ | Validated while creating this document ([opencourts-infra#25](https://github.com/opencourtsfyi/opencourts-infra/issues/25)) |
+| macOS | — | — | — | — | — | — | — | **Pending** — no Mac hardware available for this PR; track in a follow-up or volunteer sign-off |
+
+## Future automation
+
+Possible follow-ups (not required to close [opencourts-infra#25](https://github.com/opencourtsfyi/opencourts-infra/issues/25)):
+
+- [Docs as Tests](https://www.docsastests.com/) runner that executes README setup commands in CI
+- Self-hosted macOS / WSL2 GitHub Actions runners

--- a/scripts/verify_dev_stack.sh
+++ b/scripts/verify_dev_stack.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Cross-platform dev stack verification (opencourts-infra#25).
+# Runs compose up → seed → verify_catalog → compose down from the repo root.
+# See docs/CROSS_PLATFORM_VERIFICATION.md.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+CKAN_URL="${CKAN_URL:-http://localhost:5000/api/action/status_show}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-60}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-10}"
+TOKEN_NAME="${TOKEN_NAME:-manual-verify-token}"
+
+step_pass() {
+  echo "PASS: $*"
+}
+
+step_fail() {
+  echo "FAIL: $*" >&2
+}
+
+on_exit() {
+  local status=$?
+  echo
+  if [ "$status" -eq 0 ]; then
+    step_pass "Cross-platform dev stack verification completed successfully."
+    echo "All steps passed: setup, compose up, CKAN ready, seed, catalogue smoke test, compose down."
+  else
+    step_fail "Cross-platform dev stack verification failed (exit code ${status})."
+    echo "Review the output above, fix the issue, and re-run: ./scripts/verify_dev_stack.sh" >&2
+  fi
+  exit "$status"
+}
+
+trap on_exit EXIT
+
+if [ ! -x bin/compose ]; then
+  step_fail "Run this script from the opencourts-ckan repository root (bin/compose not found)."
+  exit 1
+fi
+
+echo "=== Cross-platform dev stack verification ==="
+echo "Repo: ${ROOT}"
+echo
+
+echo "Step 1/6: Setup (.env)"
+cp .env.example .env
+step_pass "Step 1/6: .env ready"
+
+echo "Step 2/6: Compose build and up"
+bin/compose build
+bin/compose up -d
+step_pass "Step 2/6: Dev stack is up"
+
+echo "Step 3/6: Wait for CKAN"
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  if curl -fsS "$CKAN_URL" > /dev/null; then
+    step_pass "Step 3/6: CKAN ready at ${CKAN_URL} (attempt ${attempt}/${MAX_ATTEMPTS})"
+    break
+  fi
+  if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+    step_fail "Step 3/6: CKAN did not become healthy at ${CKAN_URL} within $((MAX_ATTEMPTS * SLEEP_SECONDS)) seconds"
+    exit 1
+  fi
+  echo "Waiting for CKAN... (attempt ${attempt}/${MAX_ATTEMPTS})"
+  sleep "$SLEEP_SECONDS"
+done
+
+echo "Step 4/6: Seed database"
+CKAN_API_TOKEN="$(./bin/ckan user token add ckan_admin "$TOKEN_NAME" | tail -1 | tr -d '[:space:]')"
+uv run scripts/seed.py "$CKAN_API_TOKEN"
+step_pass "Step 4/6: Database seeded"
+
+echo "Step 5/6: Catalogue smoke test"
+echo "Waiting for Solr indexing after seed..."
+sleep 10
+if uv run scripts/verify_catalog.py; then
+  step_pass "Step 5/6: Catalogue smoke test"
+else
+  echo "First verify attempt failed; retrying once after additional delay..."
+  sleep 15
+  uv run scripts/verify_catalog.py
+  step_pass "Step 5/6: Catalogue smoke test (second attempt)"
+fi
+
+echo "Step 6/6: Compose down"
+bin/compose down -v
+step_pass "Step 6/6: Dev stack torn down"


### PR DESCRIPTION
# Summary
* Adds cross-platform dev stack verification for [opencourts-infra#25](https://github.com/opencourtsfyi/opencourts-infra/issues/25).
* Linux is covered by existing CI. Windows manually verified; macOS deferred (see follow-ups).

# Test plan

- [x]  Windows (WSL2) — full manual run, 2026-06-25

- [x] Linux — existing catalog-smoke.yml (unchanged)

- [ ] *macOS — not tested

# Follow-up

* *macOS options:
   - **sign off now**: a volunteer runs checklist or `./scripts/verify_dev_stack.sh` and we update sign-off log in `docs/CROSS_PLATFORM_VERIFICATION.md` OR
   - **defer macOS sign off**: we'd probably want to link to a new ticket

* [ ] After [PR #55](https://github.com/opencourtsfyi/opencourts-ckan/pull/55) merges — rebase onto main, resolve README/docs conflicts, fix TROUBLESHOOTING links
  > **NOTE**: this is really more of a suggestion, not hard requirement. If we merge this PR first, I'll put a similar task/reminder on [PR #55](https://github.com/opencourtsfyi/opencourts-ckan/pull/55)